### PR TITLE
docs: list /confirm among unversioned routes in gotchas checklist

### DIFF
--- a/apps/docs/src/content/docs/gotchas.md
+++ b/apps/docs/src/content/docs/gotchas.md
@@ -75,7 +75,7 @@ Read this before you debug something that's already a known sharp edge.
     polling transport instead.
 13. **Manual `curl` testing needs the `/v1` prefix.** Most routes live under
     `{prefix}/v1/...`; only `/health`, `/metrics`, `/track/*`, `/unsubscribe`,
-    and `/webhooks/:provider` deliberately stay unversioned (see
+    `/confirm`, and `/webhooks/:provider` deliberately stay unversioned (see
     [API versioning](/backend/#api-versioning)). `curl .../emito/preferences`
     404s with `ROUTE_NOT_FOUND`; the real path is `.../emito/v1/preferences`.
     The client SDKs already append `/v1` for you, so this only bites when


### PR DESCRIPTION
backend.md's API-versioning table already lists /confirm alongside
/unsubscribe as deliberately unversioned; the gotchas checklist's
curl-testing tip omitted it, which would send someone hunting for a
/v1/confirm route that doesn't exist.
